### PR TITLE
Fix retrieval of file when oembeding stuff

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,6 +28,10 @@ if (isset($_GET['action']) && $_GET['action'] == "oembed") {
 		exit;
 	}
 
+    // get the file name from the url
+    parse_str(parse_url($_GET['url'], PHP_URL_QUERY), $query);
+    $track = $query["file"];
+
 	$response = array("author_name" => "Jan Vonde",
 			  "author_url" => "http://blog.pregos.info",
 			  "cache_age" => "86400",


### PR DESCRIPTION
The file name is not at parameter 'file' but inside the url parameter as a query string. The url for which a representation is searched is given back to the endpoint, so that url must be parsed for the file.
